### PR TITLE
Move to GitHub actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: [ '2.4', '2.5', '2.6', '2.7', 'debug', 'jruby' ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Ruby, JRuby and TruffleRuby
+        uses: ruby/setup-ruby@v1
+
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler: true
+          bundler-cache: true
+
+      - name: Run a one-line script
+        run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', 'debug', 'jruby' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', 'debug' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
 
         with:
           ruby-version: ${{matrix.ruby}}
-          bundler: true
           bundler-cache: true
 
       - name: Run a one-line script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Ruby, JRuby and TruffleRuby
+      - name: Set up Ruby, JRuby and TruffleRuby
         uses: ruby/setup-ruby@v1
 
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
 
-      - name: Run a one-line script
+      - name: Run tests
         run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.4
-  - 2.3.1
-  - jruby-9.1.3.0
-before_install: gem install bundler -v 1.10.6


### PR DESCRIPTION
Also update Ruby test matrix to more modern versions.

I figure as long as we're (at least temporarily) maintaining this fork, I'd play around with Actions some more. We can propose this upstream if the other PR gets traction.